### PR TITLE
Add support for HTML tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,33 @@ the character used to represent bullets.
         <li>bar</li>
     </ul>
 
+### Table tags
+ - `table`, `tbody`, `tfoot`, `tr`, `th`, `td`
+
+ Width of columns is determined automatically. Optionally, a fixed column size can be specified using the `col-sizes` parameter. 
+ Each number specifies how wide a column should be and is a fraction of the sum of all column sizes. 
+ In this example, column 1 and 3 each will occupy 1/4 of the available space, while column 2 will occupy 2/4 of the available space.
+
+ ```
+<table col-sizes="1,2,1">
+  <tr>
+    <th>Amount</th>
+    <th>Description</th>
+    <th>Price</th>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>Beer 0.5L</td>
+    <td align="right">€ 8.00</td>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>Coca Cola 0.3L</td>
+    <td align="right">€ 3.50</td>
+  </tr>
+</table>
+ ```
+
 ### Image Tags
 The `img` tag prints the picture specified by the `src` attribute. 
 The `src` attribute must contain the picture encoded in png, gif 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ the character used to represent bullets.
     </ul>
 
 ### Table tags
- - `table`, `tbody`, `tfoot`, `tr`, `th`, `td`
+ - `table`, `thead`, `tbody`, `tfoot`, `tr`, `th`, `td`
 
  Width of columns is determined automatically. Optionally, a fixed column size can be specified using the `col-sizes` parameter. 
  Each number specifies how wide a column should be and is a fraction of the sum of all column sizes. 

--- a/test_printer.py
+++ b/test_printer.py
@@ -11,6 +11,13 @@ test_temp = """
             <left>TOTAL</left>
             <right>0.15</right>
         </line>
+        <table col-sizes="1,2,2">
+            <tr>
+                <td>2</td>
+                <td align="center">Product</td>
+                <td align="right">10.00</td>
+            </tr>
+        </table>
         <barcode encoding='ean13'>
             5449000000996
         </barcode>

--- a/xmlescpos/layout.py
+++ b/xmlescpos/layout.py
@@ -455,11 +455,11 @@ class XmlTableLayout(object):
 
     def print_elem(self, elem, col_sizes=None):
         # don't print if it's an uknown element
-        if elem.tag not in ('table', 'tbody', 'tfoot'):
+        if elem.tag not in ('table', 'thead', 'tbody', 'tfoot'):
             return
         
         self.stylestack.push()
-        if elem.tag == 'tbody':
+        if elem.tag == 'thead':
             self.stylestack.set({'underline': 'on'})
         elif elem.tag == 'tfoot':
             self.stylestack.set({'underline': 'double'})
@@ -499,7 +499,7 @@ class XmlTableLayout(object):
             if child.tag == 'tr':
                 self._print_table_row(child, col_sizes)
             else:
-                # nested tbody or tfoot
+                # nested thead, tbody or tfoot
                 self.print_elem(child, col_sizes)
 
         self.stylestack.pop()

--- a/xmlescpos/layout.py
+++ b/xmlescpos/layout.py
@@ -408,6 +408,9 @@ class XmlTableLayout(object):
         # iterate over transposed sublines
         for line in map(list, itertools.zip_longest(*sublines, fillvalue=(None, None))):
             for idx, (col, style) in enumerate(line):
+                is_first_index = idx == 0
+                is_last_index = idx == (len(col_sizes) - 1)
+                
                 col_width = col_sizes[idx]
                 self.stylestack.push()
                 align = None
@@ -425,11 +428,17 @@ class XmlTableLayout(object):
 
                 self.serializer.start_inline(self.stylestack)
                 text = (col or '')
-                # -1 takes care for the additional space character
-                # that is introduced by serializer.start_inline()
-                if idx > 0:
+                # makes sure spacing is not added before first col
+                if not is_first_index:
+                    # -1 takes care for the additional space character
+                    # that is introduced by serializer.start_inline()
                     text = ' ' * self._get_width(self.col_spacing - 1) + text
-                pad_size = self._get_width(col_width - 1)
+
+                # again, this -1 takes care for the additional space character
+                # that is introduced by serializer.start_inline()
+                # but for the last column, no serializer.start_inline() will follow
+                # that's why in this case we need to actually fully pad the text
+                pad_size = self._get_width(col_width - (0 if is_last_index else 1))
                 
                 if align == 'right':
                     text = text.rjust(pad_size)

--- a/xmlescpos/layout.py
+++ b/xmlescpos/layout.py
@@ -465,11 +465,13 @@ class XmlTableLayout(object):
             self.stylestack.set({'underline': 'double'})
         
         # with col-sizes one can specify the size ratio for all columns
-        col_sizes = elem.attrib.get('col-sizes', None)
-        if col_sizes:
-            # convert comma separated string into int list
-            col_sizes = list(map(int, col_sizes.split(',')))
-            col_sizes = self._normalize_colsizes(col_sizes)
+        # only allow this, if col_sizes does not exist
+        if not col_sizes:
+            col_sizes = elem.attrib.get('col-sizes', None)
+            if col_sizes:
+                # convert comma separated string into int list
+                col_sizes = list(map(int, col_sizes.split(',')))
+                col_sizes = self._normalize_colsizes(col_sizes)
 
         # if col_sizes is not specified, iterate over all columns
         # and find their respective text size

--- a/xmlescpos/layout.py
+++ b/xmlescpos/layout.py
@@ -8,6 +8,8 @@ import hashlib
 import re
 import xml.etree.ElementTree as ET
 from PIL import Image
+import textwrap
+import itertools
 
 from escpos.constants import PrinterCommands, StarCommands, QR_ECLEVEL_L, QR_MODEL_2, CTL_FF
 
@@ -325,6 +327,155 @@ class XmlLineSerializer:
         return ' ' * self.indent * self.tabwidth + self.lbuffer + ' ' * \
             (self.width - self.clwidth - self.crwidth) + self.rbuffer
 
+class XmlTableLayout(object):
+    """ Helper class. Parses an XML table layout.
+
+    Convert to ESC/POS. Send to a pyton-escpos printer object.
+    """
+    def __init__(self, stylestack, serializer, min_col_size=5, col_spacing=4):
+        """ Parameters:
+        
+        stylestack (Stylestack): the currently used stylestack
+        serializer (XmlSerializer): the currently used serializer
+        min_col_size (int): minimum size of a column (in characters)
+        col_spacing (int): number of whitespace characters between columns
+        """
+        self.stylestack = stylestack
+        self.serializer = serializer
+        self.min_col_size = min_col_size
+        self.col_spacing = col_spacing
+
+    def _normalize_colsizes(self, col_sizes):
+        """ Normalizes a list of column sizes to match the maximum available 
+        amount of characters on the receipt.
+        """
+        # find largest col size index
+        max_col_idx = max(range(len(col_sizes)), key=lambda i: col_sizes[i])
+        # retreive default width for receipt
+        width = self.stylestack.get('width')
+
+        # build sum for col size normaliziation
+        sum_col_size = sum(col_sizes)
+        for idx, col in enumerate(col_sizes):
+            # normalize col size (into real number)
+            size = col / sum_col_size * width
+            # each col must be at least n chars wide
+            if size < self.min_col_size:
+                size = self.min_col_size
+
+            # round to next integer, as width is measured
+            # in characters
+            col_sizes[idx] = round(size)
+
+        # ensure that sum of all columns does not exceed maximum receipt width
+        # all overflow is deducted from largest column
+        col_sizes[max_col_idx] -= max(0, sum(col_sizes) - width)
+        return col_sizes
+
+    def _print_table_row(self, elem, col_sizes):
+        sublines = []
+
+        # in this loop, split each line into one or more lines
+        # depending on the length of the text
+        for idx, td in enumerate(elem):
+            try:
+                col_width = col_sizes[idx]
+            except IndexError:
+                # catch index error as it could happen that XML
+                # specifies an incorrect (too few) amount of columns
+                raise Exception(f'Attribute "col-sizes" only contains {len(col_sizes)} elements but {len(elem)} required')
+            
+            sublines.append(zip(
+                textwrap.wrap(td.text, width=col_width - self.col_spacing),
+                itertools.repeat({
+                    # enable bold mode if tag name is "th"
+                    'bold': 'on' if td.tag == 'th' else 'off'
+                    # copy rest of attributes
+                    **td.attrib,
+                })
+            ))
+
+        # iterate over transposed sublines
+        for line in map(list, itertools.zip_longest(*sublines, fillvalue=(None, None))):
+            for idx, (col, style) in enumerate(line):
+                col_width = col_sizes[idx]
+                self.stylestack.push()
+                align = None
+
+                if (style):
+                    # extract the align attribute
+                    align = style.get('align')
+                    # ... and overwrite it with left
+                    # the default ESC command for alignment
+                    # does not work in this case, as it only works line-wise
+                    # but as we are constructing our own table here
+                    # all other aligns than 'left' destroy the layout
+                    style['align'] = 'left'
+                    self.stylestack.set(style)
+
+                self.serializer.start_inline(self.stylestack)
+                text = (col or '')
+                # -1 takes care for the additional space character
+                # that is introduced by serializer.start_inline()
+                if idx > 0:
+                    text = ' ' * (self.col_spacing - 1) + text
+                pad_size = col_width - 1
+                
+                if align == 'right':
+                    text = text.rjust(pad_size)
+                elif align == 'center':
+                    text = text.center(pad_size)
+                else:
+                    text = text.ljust(pad_size)
+
+                self.serializer.pre(text)
+                self.serializer.end_entity()
+                self.stylestack.pop()
+
+            self.serializer.linebreak()
+
+    def print_elem(self, elem, col_sizes=None):
+        # don't print if it's an uknown element
+        if elem.tag not in ('table', 'tbody', 'tfoot'):
+            return
+        
+        # with col-sizes one can specify the size ratio for all columns
+        col_sizes = elem.attrib.get('col-sizes', None)
+        if col_sizes:
+            # convert comma separated string into int list
+            col_sizes = list(map(int, col_sizes.split(',')))
+            col_sizes = self._normalize_colsizes(col_sizes)
+
+        # if col_sizes is not specified, iterate over all columns
+        # and find their respective text size
+        if not col_sizes:
+            col_sizes = []
+            for child in elem:
+                # only consider tr elements
+                if child.tag != 'tr':
+                    continue
+
+                # iterate all tds
+                for idx, td in enumerate(child):
+                    textlen = len(td.text)
+                    if idx == len(col_sizes):
+                        # if current td index is the same as the list's length
+                        # we add another item
+                        col_sizes.append(textlen)
+                    else:
+                        # store the maximum text length
+                        col_sizes[idx] = max(col_sizes[idx], textlen)
+
+            # finally, normalize everything
+            col_sizes = self._normalize_colsizes(col_sizes)
+            
+        # now print all rows/columns
+        for child in elem:
+            if child.tag == 'tr':
+                self._print_table_row(child, col_sizes)
+            else:
+                # nested tbody or tfoot
+                self.print_elem(child, col_sizes)
 
 class Layout(object):
     """Main class. Parses an XML layout.
@@ -506,6 +657,9 @@ class Layout(object):
                     printer,
                     indent=indent + 1)
             serializer.end_entity()
+
+        elif elem.tag == 'table':
+            XmlTableLayout(stylestack, serializer).print_elem(elem)
 
         elif elem.tag == 'pre':
             serializer.start_block(stylestack)

--- a/xmlescpos/layout.py
+++ b/xmlescpos/layout.py
@@ -396,7 +396,7 @@ class XmlTableLayout(object):
                 raise Exception(f'Attribute "col-sizes" only contains {len(col_sizes)} elements but {len(elem)} required')
             
             sublines.append(zip(
-                textwrap.wrap(td.text, width=self._get_width(col_width - self.col_spacing)),
+                textwrap.wrap(td.text or '', width=self._get_width(col_width - self.col_spacing)),
                 itertools.repeat({
                     # enable bold mode if tag name is "th"
                     'bold': 'on' if td.tag == 'th' else 'off',
@@ -449,6 +449,12 @@ class XmlTableLayout(object):
         if elem.tag not in ('table', 'tbody', 'tfoot'):
             return
         
+        self.stylestack.push()
+        if elem.tag == 'tbody':
+            self.stylestack.set({'underline': 'on'})
+        elif elem.tag == 'tfoot':
+            self.stylestack.set({'underline': 'double'})
+        
         # with col-sizes one can specify the size ratio for all columns
         col_sizes = elem.attrib.get('col-sizes', None)
         if col_sizes:
@@ -467,7 +473,7 @@ class XmlTableLayout(object):
 
                 # iterate all tds
                 for idx, td in enumerate(child):
-                    textlen = len(td.text)
+                    textlen = len(td.text or '')
                     if idx == len(col_sizes):
                         # if current td index is the same as the list's length
                         # we add another item
@@ -486,6 +492,8 @@ class XmlTableLayout(object):
             else:
                 # nested tbody or tfoot
                 self.print_elem(child, col_sizes)
+
+        self.stylestack.pop()
 
 class Layout(object):
     """Main class. Parses an XML layout.


### PR DESCRIPTION
Hey @chrisv2,
first of all thanks for the amazing library, it's already been of great use for me.

The only thing that was missing to me was support for HTML `table`, so I though why not implement it.

I quickly realized that it's not going to be as easy as other block elements, so there are currently a few drawbacks. 

As breaking words into multiple lines had to be coded manually, I figured it would be the easiest choice to not allow any nested inline elements within `td`. I had to implement a function that splits long strings into several lines, depending on the column's width. The lines are then printed just as regular lines utilizing `serializer.pre()`. I think allowing inline elements would make the implementation even more painful (thinking about `ul` nested inside a `td` for example).

Another argument speaking against nesting elements within `td` was readability. I don't think it makes a lot of sense to have (just as an example) a `ul` within a `td`, as the printed receipt would just look messy.

I'd appreciate if you had a look at it and I'm looking forward to getting feedback from you.

Best regards
Gabriel